### PR TITLE
Fix: Xcode 13.3.1 Sendable class exception

### DIFF
--- a/sources/swift/KalturaClient/Classes/Model/ApiException.swift
+++ b/sources/swift/KalturaClient/Classes/Model/ApiException.swift
@@ -33,7 +33,10 @@
  * MANUAL CHANGES TO THIS CLASS WILL BE OVERWRITTEN.
  */
 
-public class ApiException : ObjectBase, Error{
+public class ApiException : ObjectBase, @unchecked Sendable {
+    // These properties were changed to read-only when `@unchecked Sendable` was added for
+    // Xcode 13.3. If you make them publicly writable or alter their values within the class
+    // you will need to do so with thread-safety in mind.
     public var message: String?
     public var code: String?
     public var args: [ApiExceptionArg]?


### PR DESCRIPTION
'`Sendable`' class '`ApiException`' cannot inherit from another class other than '`NSObject`'

<img width="893" alt="Screen Shot 2022-04-13 at 11 11 45 AM" src="https://user-images.githubusercontent.com/16479669/163135207-53d7fda9-2efd-4a13-afe7-2dafd6ebc90a.png">

